### PR TITLE
fix a bug on GraalVM

### DIFF
--- a/src/main/java/com/github/games647/craftapi/cache/SafeCacheBuilder.java
+++ b/src/main/java/com/github/games647/craftapi/cache/SafeCacheBuilder.java
@@ -149,18 +149,25 @@ public class SafeCacheBuilder<K, V> {
      * @throws IllegalStateException    if a maximum size was already set
      */
     public SafeCacheBuilder<K, V> maximumSize(int size) {
+        boolean isLong;
         try {
             MAXIMUM_SIZE_METHOD = builder.getClass().getDeclaredMethod("maximumSize", Long.TYPE);
+            isLong = true;
         } catch (NoSuchMethodException noSuchMethodEx) {
             try {
                 MAXIMUM_SIZE_METHOD = builder.getClass().getDeclaredMethod("maximumSize", Integer.TYPE);
+                isLong = false;
             } catch (NoSuchMethodException e) {
                 throw new IllegalStateException("Unable to find CacheBuilder.maximumSize(Int|Long)", e);
             }
         }
 
         try {
-            MAXIMUM_SIZE_METHOD.invoke(builder, size);
+            if (isLong) {
+                MAXIMUM_SIZE_METHOD.invoke(builder, (long) size);
+            } else {
+                MAXIMUM_SIZE_METHOD.invoke(builder, size);
+            }
         } catch (Exception e) {
             throw new IllegalStateException("Unable to invoke CacheBuilder.maximumSize(Int|Long)", e);
         }


### PR DESCRIPTION
log:
```
Caused by: java.lang.IllegalArgumentException: cannot cast java.lang.Integer to java.lang.Long
	at com.oracle.svm.reflect.helpers.ExceptionHelpers.createFailedCast(ExceptionHelpers.java:30) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at com.github.games647.craftapi.cache.SafeCacheBuilder.maximumSize(SafeCacheBuilder.java:163) ~[?:?]
```