### PR TITLE
Add fallback url for uuid checking, incase the main url responds with 403

### DIFF
--- a/src/main/java/com/github/games647/craftapi/resolver/AbstractResolver.java
+++ b/src/main/java/com/github/games647/craftapi/resolver/AbstractResolver.java
@@ -121,6 +121,8 @@ public abstract class AbstractResolver implements Closeable {
     }
 
     private void closeClient(HttpClient proxyClient) throws IOException {
+        // autoclosable check is required, because the interface was later introduced
+        //noinspection DataFlowIssue
         if (proxyClient instanceof AutoCloseable) {
             AutoCloseable closeableClient = (AutoCloseable) client;
             try {

--- a/src/main/java/com/github/games647/craftapi/resolver/MojangResolver.java
+++ b/src/main/java/com/github/games647/craftapi/resolver/MojangResolver.java
@@ -49,7 +49,7 @@ public class MojangResolver extends AbstractResolver implements AuthResolver, Pr
     //profile
     private static final String UUID_URL = "https://api.mojang.com/users/profiles/minecraft/";
     private static final String BACKUP_UUID_URL = "https://api.minecraftservices.com/minecraft/profile/lookup/name/";
-    private boolean useBackupUuidUrl = false;
+    private boolean useBackupUuidUrl;
 
     //skin
     private static final String CHANGE_SKIN_URL = "https://api.mojang.com/user/profile/%s/skin";
@@ -199,10 +199,13 @@ public class MojangResolver extends AbstractResolver implements AuthResolver, Pr
 
             if (responseCode == HttpURLConnection.HTTP_FORBIDDEN) {
                 if (useBackupUuidUrl) {
-                    return Optional.empty();
+                    throw new IOException("Both Mojang APIs returned 403 Forbidden");
                 }
+
                 useBackupUuidUrl = true;
-                String backupUrl = BACKUP_UUID_URL + req.uri().getPath().substring(req.uri().getPath().lastIndexOf("/") + 1);
+                // extract only the username and query parameters
+                String backupUrl = BACKUP_UUID_URL + req.uri().getPath()
+                    .substring(req.uri().getPath().lastIndexOf('/') + 1);
                 HttpRequest backupReq = createJSONGet(backupUrl);
                 return findProfile(client, backupReq);
             }


### PR DESCRIPTION
### Summary of your change
Incase the api.mojang.com responds with 403, starts using api.minecraftservices.com.
This helps resolve issues that come with mojangs bad api uptime's
### Related issue
Fixes:
https://github.com/TuxCoding/FastLogin/issues/1305